### PR TITLE
Fixed url parsing.

### DIFF
--- a/instaram_slider.php
+++ b/instaram_slider.php
@@ -928,9 +928,14 @@ class JR_InstagramSlider extends WP_Widget {
 	 */
 	private function save_wp_attachment( $image_data ) {
 		
-		$image_info = pathinfo( $image_data['url'] );
+		// get path from url
+		$url_path = parse_url($image_data['url'], PHP_URL_PATH);
 		
+		// get file name from path
+		$image_info = pathinfo( $url_path );
+
 		if ( !in_array( $image_info['extension'], array( 'jpg', 'jpe', 'jpeg', 'gif', 'png' ) ) ) {
+			error_log('Unknown extension in url '.$image_data['url']);
 			return false;
 		}
 		


### PR DESCRIPTION
The url was parsed to retrieve the file name. However the parsing was just done using pathinfo which doesn't take url parameters into account. I added a parse_url to extract the path and used pathinfo on the output.
This issue was leading to a wrong file extension if a url parameters contained a period.
